### PR TITLE
#3 [THEME] Make background and text colors configurable in input components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## @dev
-- Made ComboBox component colors and fonts configurable with theme system
+- Made ComboBox component colors and fonts configurable with theme system  
+- Made input box components configurable for custom themes
 - Replaced hardcoded "Arial" font with `themeConfig.uiFont`
 - [DEV] Added debug option to always show session selector
 

--- a/src/components/Main.qml
+++ b/src/components/Main.qml
@@ -563,47 +563,31 @@ Rectangle {
                     font.family: themeConfig.uiFont
                 }
 
-                Rectangle {
+                TextBox {
                     id: name
                     width: parent.width
                     height: 45
-                    radius: 6
-                    color: themeConfig.uiBackgroundColor
-                    border.color: nameInput.activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
+                    backgroundColor: themeConfig.uiBackgroundColor
+                    textColor: themeConfig.uiTextColor
+                    border.color: activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
                     border.width: 2
+                    
+                    text: userModel.lastUser || ""
+                    font.pixelSize: 16
+                    font.family: "Arial"
 
-                    property alias text: nameInput.text
+                    Keys.backtab: rebootButton
+                    Keys.tab: password
 
-                    function forceActiveFocus(reason) {
-                        nameInput.forceActiveFocus(reason)
-                    }
+                    onFocusChanged: resetHideTimer()
+                    onTextChanged: recordActivity()
 
-                    TextInput {
-                        id: nameInput
-                        anchors.fill: parent
-                        anchors.margins: 8
-
-                        text: userModel.lastUser || ""
-                        color: themeConfig.uiTextColor
-                        font.pixelSize: 16
-                        font.family: "Arial"
-                        selectByMouse: true
-                        verticalAlignment: TextInput.AlignVCenter
-
-                        KeyNavigation.backtab: rebootButton
-                        KeyNavigation.tab: password
-
-                        onActiveFocusChanged: resetHideTimer()
-                        onTextChanged: recordActivity()
-
-                        Keys.onPressed: function(event) {
-                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
-                                event.accepted = true
-                            } else {
-                                // Record activity on any keystroke
-                                recordActivity()
-                            }
+                    Keys.onPressed: function(event) {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            sddm.login(name.text, password.text, sessionIndex)
+                            event.accepted = true
+                        } else {
+                            recordActivity()
                         }
                     }
                 }
@@ -621,47 +605,30 @@ Rectangle {
                     font.family: themeConfig.uiFont
                 }
 
-                Rectangle {
+                PasswordBox {
                     id: password
                     width: parent.width
                     height: 45
-                    radius: 6
-                    color: themeConfig.uiBackgroundColor
-                    border.color: passwordInput.activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
+                    backgroundColor: themeConfig.uiBackgroundColor
+                    textColor: themeConfig.uiTextColor
+                    border.color: activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
                     border.width: 2
+                    
+                    font.pixelSize: 16
+                    font.family: "Arial"
 
-                    property alias text: passwordInput.text
+                    KeyNavigation.backtab: name
+                    KeyNavigation.tab: session
 
-                    function forceActiveFocus(reason) {
-                        passwordInput.forceActiveFocus(reason)
-                    }
+                    onFocusChanged: resetHideTimer()
+                    onTextChanged: recordActivity()
 
-                    TextInput {
-                        id: passwordInput
-                        anchors.fill: parent
-                        anchors.margins: 8
-
-                        color: themeConfig.uiTextColor
-                        font.pixelSize: 16
-                        font.family: "Arial"
-                        selectByMouse: true
-                        echoMode: TextInput.Password
-                        verticalAlignment: TextInput.AlignVCenter
-
-                        KeyNavigation.backtab: name
-                        KeyNavigation.tab: session
-
-                        onActiveFocusChanged: resetHideTimer()
-                        onTextChanged: recordActivity()
-
-                        Keys.onPressed: function(event) {
-                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
-                                event.accepted = true
-                            } else {
-                                // Record activity on any keystroke
-                                recordActivity()
-                            }
+                    Keys.onPressed: function(event) {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            sddm.login(name.text, password.text, sessionIndex)
+                            event.accepted = true
+                        } else {
+                            recordActivity()
                         }
                     }
                 }

--- a/src/components/Main.qml
+++ b/src/components/Main.qml
@@ -563,31 +563,47 @@ Rectangle {
                     font.family: themeConfig.uiFont
                 }
 
-                TextBox {
+                Rectangle {
                     id: name
                     width: parent.width
                     height: 45
-                    backgroundColor: themeConfig.uiBackgroundColor
-                    textColor: themeConfig.uiTextColor
-                    border.color: activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
+                    radius: 6
+                    color: themeConfig.uiBackgroundColor
+                    border.color: nameInput.activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
                     border.width: 2
-                    
-                    text: userModel.lastUser || ""
-                    font.pixelSize: 16
-                    font.family: "Arial"
 
-                    Keys.backtab: rebootButton
-                    Keys.tab: password
+                    property alias text: nameInput.text
 
-                    onFocusChanged: resetHideTimer()
-                    onTextChanged: recordActivity()
+                    function forceActiveFocus(reason) {
+                        nameInput.forceActiveFocus(reason)
+                    }
 
-                    Keys.onPressed: function(event) {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            sddm.login(name.text, password.text, sessionIndex)
-                            event.accepted = true
-                        } else {
-                            recordActivity()
+                    TextInput {
+                        id: nameInput
+                        anchors.fill: parent
+                        anchors.margins: 8
+
+                        text: userModel.lastUser || ""
+                        color: themeConfig.uiTextColor
+                        font.pixelSize: 16
+                        font.family: "Arial"
+                        selectByMouse: true
+                        verticalAlignment: TextInput.AlignVCenter
+
+                        KeyNavigation.backtab: rebootButton
+                        KeyNavigation.tab: password
+
+                        onActiveFocusChanged: resetHideTimer()
+                        onTextChanged: recordActivity()
+
+                        Keys.onPressed: function(event) {
+                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                sddm.login(name.text, password.text, sessionIndex)
+                                event.accepted = true
+                            } else {
+                                // Record activity on any keystroke
+                                recordActivity()
+                            }
                         }
                     }
                 }
@@ -605,30 +621,47 @@ Rectangle {
                     font.family: themeConfig.uiFont
                 }
 
-                PasswordBox {
+                Rectangle {
                     id: password
                     width: parent.width
                     height: 45
-                    backgroundColor: themeConfig.uiBackgroundColor
-                    textColor: themeConfig.uiTextColor
-                    border.color: activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
+                    radius: 6
+                    color: themeConfig.uiBackgroundColor
+                    border.color: passwordInput.activeFocus ? themeConfig.uiSecondaryColor : themeConfig.uiPrimaryColor
                     border.width: 2
-                    
-                    font.pixelSize: 16
-                    font.family: "Arial"
 
-                    KeyNavigation.backtab: name
-                    KeyNavigation.tab: session
+                    property alias text: passwordInput.text
 
-                    onFocusChanged: resetHideTimer()
-                    onTextChanged: recordActivity()
+                    function forceActiveFocus(reason) {
+                        passwordInput.forceActiveFocus(reason)
+                    }
 
-                    Keys.onPressed: function(event) {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            sddm.login(name.text, password.text, sessionIndex)
-                            event.accepted = true
-                        } else {
-                            recordActivity()
+                    TextInput {
+                        id: passwordInput
+                        anchors.fill: parent
+                        anchors.margins: 8
+
+                        color: themeConfig.uiTextColor
+                        font.pixelSize: 16
+                        font.family: "Arial"
+                        selectByMouse: true
+                        echoMode: TextInput.Password
+                        verticalAlignment: TextInput.AlignVCenter
+
+                        KeyNavigation.backtab: name
+                        KeyNavigation.tab: session
+
+                        onActiveFocusChanged: resetHideTimer()
+                        onTextChanged: recordActivity()
+
+                        Keys.onPressed: function(event) {
+                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                sddm.login(name.text, password.text, sessionIndex)
+                                event.accepted = true
+                            } else {
+                                // Record activity on any keystroke
+                                recordActivity()
+                            }
                         }
                     }
                 }

--- a/src/components/PasswordBox.qml
+++ b/src/components/PasswordBox.qml
@@ -21,13 +21,14 @@ Rectangle {
     property alias selectByMouse: textInput.selectByMouse
     property string placeholderText: "Password"
 
-    // Override color to control text color, not background
-    property alias textColor: textInput.color
+    // Configurable colors
+    property color backgroundColor: "#F0F0F0"
+    property color textColor: "#000000"
 
     width: 200
     height: 35
     radius: 6
-    color: "#00FF00"  // Bright green background
+    color: backgroundColor
     border.color: textInput.activeFocus ? "#5A7ABA" : "#3A4A6A"
     border.width: 2
 
@@ -36,7 +37,7 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: 8
 
-        color: "#000000"  // Black text
+        color: textColor
         font.pixelSize: 14
         font.family: "Arial"
         selectByMouse: true

--- a/src/components/TextBox.qml
+++ b/src/components/TextBox.qml
@@ -20,13 +20,14 @@ Rectangle {
     property alias activeFocus: textInput.activeFocus
     property alias selectByMouse: textInput.selectByMouse
 
-    // Override color to control text color, not background
-    property alias textColor: textInput.color
+    // Configurable colors
+    property color backgroundColor: "#F0F0F0"
+    property color textColor: "#000000"
 
     width: 200
     height: 35
     radius: 6
-    color: "#FF0000"  // Bright red background
+    color: backgroundColor
     border.color: textInput.activeFocus ? "#5A7ABA" : "#3A4A6A"
     border.width: 2
 
@@ -35,7 +36,7 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: 8
 
-        color: "#000000"  // Black text
+        color: textColor
         font.pixelSize: 14
         font.family: "Arial"
         selectByMouse: true


### PR DESCRIPTION
## Summary
Refactored PasswordBox and TextBox components to support configurable background and text colors instead of hardcoded bright colors.

## Changes
- Added `backgroundColor` and `textColor` properties to PasswordBox.qml and TextBox.qml
- Removed hardcoded bright green (#00FF00) background from PasswordBox
- Removed hardcoded bright red (#FF0000) background from TextBox
- Fixed non-functional `textColor` alias properties
- Components now use sensible defaults (#F0F0F0 background, #000000 text)

## Notes
Main.qml input fields were already working correctly with themes and remain unchanged.
This change only affects the standalone PasswordBox/TextBox components for future use.

Closes #3